### PR TITLE
fix: Tidy up users api request

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,11 +36,6 @@ type JoinedLabels struct {
 	Labels []*gitlab.Label
 }
 
-// JoinedUsers is a list of Users
-type JoinedUsers struct {
-	Users []*gitlab.User
-}
-
 // MergeRequestData request data combined with approvals
 type MergeRequestData struct {
 	MergeRequest *gitlab.MergeRequest
@@ -153,7 +148,6 @@ func (app *App) GetLabels(w http.ResponseWriter, r *http.Request) {
 
 // GetUsers returns a JSON array of users
 func (app *App) GetUsers(w http.ResponseWriter, r *http.Request) {
-	var userData JoinedUsers
 	git := app.gitlabClient
 
 	ListUsersOptions := &gitlab.ListUsersOptions{
@@ -168,11 +162,7 @@ func (app *App) GetUsers(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	for _, user := range users {
-		userData.Users = append(userData.Users, user)
-	}
-
-	output, err := json.Marshal(userData)
+	output, err := json.Marshal(users)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/public/app.js
+++ b/public/app.js
@@ -30,7 +30,7 @@ new Vue({
 		userAvatar: function(id) {
 			var self = this;
 			
-			var user = [...self.users.Users].filter(function(user) {
+			var user = [...self.users].filter(function(user) {
 				return user.id === id;
 			})
 			if(Object.keys(user).length !== 0) {


### PR DESCRIPTION
The users API request currently adds the users to a Struct that is
totally pointless. Remove this and use the default Users struct that
go-gitlab uses.